### PR TITLE
fix: Make sure there is only one response in data

### DIFF
--- a/config/cluster_read_config.test.yaml
+++ b/config/cluster_read_config.test.yaml
@@ -196,22 +196,22 @@
 # Results
 {%macro results_scenario(name) -%}
 - name: results.{{name}}.locust_requests_avg_response_time
-  monitoring_query: locust_requests_avg_response_time{name="{{name}}"}
+  monitoring_query: sum(locust_requests_avg_response_time{name="{{name}}"})
   monitoring_step: 15
 - name: results.{{name}}.locust_requests_avg_content_length
-  monitoring_query: locust_requests_avg_content_length{name="{{name}}"}
+  monitoring_query: sum(locust_requests_avg_content_length{name="{{name}}"})
   monitoring_step: 15
 - name: results.{{name}}.locust_requests_current_rps
-  monitoring_query: locust_requests_current_rps{name="{{name}}"}
+  monitoring_query: sum(locust_requests_current_rps{name="{{name}}"})
   monitoring_step: 15
 - name: results.{{name}}.locust_requests_current_fail_per_sec
-  monitoring_query: locust_requests_current_fail_per_sec{name="{{name}}"}
+  monitoring_query: sum(locust_requests_current_fail_per_sec{name="{{name}}"})
   monitoring_step: 15
 - name: results.{{name}}.locust_requests_num_failures
-  monitoring_query: locust_requests_num_failures{name="{{name}}"}
+  monitoring_query: sum(locust_requests_num_failures{name="{{name}}"})
   monitoring_step: 15
 - name: results.{{name}}.locust_errors
-  monitoring_query: locust_errors{name="{{name}}"}
+  monitoring_query: sum(locust_errors{name="{{name}}"})
   monitoring_step: 15
 {%- endmacro %}
 


### PR DESCRIPTION
There might be data like this:

    {
        'status': 'success',
        'data': {
            'resultType': 'matrix',
            'result': [
                {
                    'metric': {
                        '__name__': 'locust_requests_avg_response_time',
                        'container': 'locust-metrics-exporter',
                        'endpoint': 'prometheus-metrics',
                        'instance': '10.128.2.35:9646',
                        'job': 'mvp-test-master',
                        'name': 'Aggregated',
                        'namespace': 'locust-operator',
                        'pod': 'mvp-test-master-2rtl5',
                        'prometheus': 'openshift-user-workload-monitoring/user-workload',
                        'service': 'mvp-test-master'
                    },
                    'values': [
                        [1709228056, '387.54814499811835']
                    ]
                },
                {
                    'metric': {
                        '__name__': 'locust_requests_avg_response_time',
                        'container': 'locust-metrics-exporter',
                        'endpoint': 'prometheus-metrics',
                        'instance': '10.128.2.46:9646',
                        'job': 'mvp-test-master',
                        'name': 'Aggregated',
                        'namespace': 'locust-operator',
                        'pod': 'mvp-test-master-9hlzj',
                        'prometheus': 'openshift-user-workload-monitoring/user-workload',
                        'service': 'mvp-test-master'
                    },
                    'values': [
                        [1709228071, '925.4287625888538'], [1709228086, '1470.1749300681954'], [1709228101, '2156.182596251187'], [1709228116, '2117.3740125609174'], [1709228131, '2101.9880769279166'], [1709228146, '2199.479863616386'], [1709228161, '2485.2154790917293'], [1709228176, '2448.4574473097337'], [1709228191, '2414.1250702929106'], [1709228206, '2444.2160835779805'], [1709228221, '2528.3223100392597'], [1709228236, '2518.5057251476287'], [1709228251, '2521.676076221177'], [1709228266, '2529.1457884724887'], [1709228281, '2548.69447795587'], [1709228296, '2560.640720847256'], [1709228311, '2563.8768622192015'], [1709228326, '2578.944299676874'], [1709228341, '2586.787705514493'], [1709228356, '2582.892992186117'], [1709228371, '2589.8548205388893'], [1709228386, '2585.867479647283'], [1709228401, '2576.483825774135'], [1709228416, '2577.8566617293022'], [1709228431, '2575.2561719846567'], [1709228446, '2591.270312663225'], [1709228461, '2590.0634648920886'], [1709228476, '2591.638425500105'], [1709228491, '2604.0612509620596'], [1709228506, '2608.246523852518'], [1709228521, '2602.0875226316452'], [1709228536, '2602.4346144599826'], [1709228551, '2616.7663989678563'], [1709228566, '2628.015782285809'], [1709228581, '2614.704750094623'], [1709228596, '2610.288395967332'], [1709228611, '2626.2464825699'], [1709228626, '2636.3745570608785'], [1709228641, '2631.999420078156'], [1709228656, '2623.5940233418182'], [1709228671, '2619.005739752889'], [1709228686, '2619.005739752889'], [1709228701, '2619.005739752889'], [1709228716, '2619.005739752889']
                    ]
                }
            ]
        }
    }

Maybe because Locust pod restarted?