### PR TITLE
fix(RHIDP-1499): replace deprecated repo with the new rhdh-1.1-rhel-9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ export RHDH_IMAGE_TAG ?=
 
 # RHDH Helm chart to deploy
 export RHDH_NAMESPACE ?= rhdh-performance
-export RHDH_HELM_REPO ?= https://gist.githubusercontent.com/rhdh-bot/63cef5cb6285889527bd6a67c0e1c2a9/raw
+export RHDH_HELM_REPO ?= https://raw.githubusercontent.com/rhdh-bot/openshift-helm-charts/rhdh-1.1-rhel-9/installation
 export RHDH_HELM_CHART ?= developer-hub
 export RHDH_HELM_CHART_VERSION ?=
 export RHDH_HELM_RELEASE_NAME ?= rhdh

--- a/ci-scripts/rhdh-setup/deploy.sh
+++ b/ci-scripts/rhdh-setup/deploy.sh
@@ -30,7 +30,7 @@ export RHDH_IMAGE_REGISTRY=${RHDH_IMAGE_REGISTRY:-}
 export RHDH_IMAGE_REPO=${RHDH_IMAGE_REPO:-}
 export RHDH_IMAGE_TAG=${RHDH_IMAGE_TAG:-}
 
-export RHDH_HELM_REPO=${RHDH_HELM_REPO:-https://gist.githubusercontent.com/rhdh-bot/63cef5cb6285889527bd6a67c0e1c2a9/raw}
+export RHDH_HELM_REPO=${RHDH_HELM_REPO:-https://raw.githubusercontent.com/rhdh-bot/openshift-helm-charts/rhdh-1.1-rhel-9/installation}
 export RHDH_HELM_CHART=${RHDH_HELM_CHART:-developer-hub}
 export RHDH_HELM_CHART_VERSION=${RHDH_HELM_CHART_VERSION:-}
 


### PR DESCRIPTION
With [deprecation of the helm repo](https://gist.github.com/rhdh-bot/63cef5cb6285889527bd6a67c0e1c2a9#file-deprecated-md) currently used by the framework, this PR changes the repo to the new one