### PR TITLE
Helm chart name change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ export RHDH_IMAGE_TAG ?=
 # RHDH Helm chart to deploy
 export RHDH_NAMESPACE ?= rhdh-performance
 export RHDH_HELM_REPO ?= https://raw.githubusercontent.com/rhdh-bot/openshift-helm-charts/rhdh-1.1-rhel-9/installation
-export RHDH_HELM_CHART ?= developer-hub
+export RHDH_HELM_CHART ?= redhat-developer-hub
 export RHDH_HELM_CHART_VERSION ?=
 export RHDH_HELM_RELEASE_NAME ?= rhdh
 

--- a/ci-scripts/rhdh-setup/create_resource.sh
+++ b/ci-scripts/rhdh-setup/create_resource.sh
@@ -37,7 +37,7 @@ backstage_url() {
     exit 1
   }
   if [ ! -f "$f" ]; then
-    echo -n "https://$(oc get routes "${RHDH_HELM_RELEASE_NAME}-developer-hub" -n "${RHDH_NAMESPACE}" -o jsonpath='{.spec.host}')" >"$f"
+    echo -n "https://$(oc get routes "${RHDH_HELM_RELEASE_NAME}-${RHDH_HELM_CHART}" -n "${RHDH_NAMESPACE}" -o jsonpath='{.spec.host}')" >"$f"
   fi
   flock -u 5
   cat "$f"

--- a/ci-scripts/rhdh-setup/deploy.sh
+++ b/ci-scripts/rhdh-setup/deploy.sh
@@ -129,6 +129,7 @@ backstage_install() {
     envsubst \
         '${OPENSHIFT_APP_DOMAIN} \
         ${RHDH_HELM_RELEASE_NAME} \
+        ${RHDH_HELM_CHART} \
         ${RHDH_DEPLOYMENT_REPLICAS} \
         ${RHDH_DB_REPLICAS} \
         ${RHDH_DB_STORAGE} \

--- a/ci-scripts/rhdh-setup/template/backstage/chart-values.image-override.yaml
+++ b/ci-scripts/rhdh-setup/template/backstage/chart-values.image-override.yaml
@@ -58,7 +58,7 @@ upstream:
         valueFrom:
           secretKeyRef:
             key: backend-secret
-            name: "{{ .Release.Name }}-developer-hub-auth"
+            name: "{{ .Release.Name }}-auth"
       - name: GITHUB_TOKEN
         valueFrom:
           secretKeyRef:

--- a/ci-scripts/rhdh-setup/template/backstage/chart-values.yaml
+++ b/ci-scripts/rhdh-setup/template/backstage/chart-values.yaml
@@ -58,7 +58,7 @@ upstream:
         valueFrom:
           secretKeyRef:
             key: backend-secret
-            name: "{{ .Release.Name }}-developer-hub-auth"
+            name: "{{ .Release.Name }}-auth"
       - name: GITHUB_TOKEN
         valueFrom:
           secretKeyRef:

--- a/ci-scripts/rhdh-setup/template/keycloak/keycloakClient.yaml
+++ b/ci-scripts/rhdh-setup/template/keycloak/keycloakClient.yaml
@@ -17,7 +17,7 @@ spec:
     implicitFlowEnabled: false
     publicClient: false
     redirectUris:
-      - https://${RHDH_HELM_RELEASE_NAME}-developer-hub-${RHDH_NAMESPACE}.${OPENSHIFT_APP_DOMAIN}/oauth2/callback
+      - https://${RHDH_HELM_RELEASE_NAME}-${RHDH_HELM_CHART}-${RHDH_NAMESPACE}.${OPENSHIFT_APP_DOMAIN}/oauth2/callback
     serviceAccountsEnabled: true
     standardFlowEnabled: true
   realmSelector:


### PR DESCRIPTION
Helm chart name has been changed from developer-hub to redhat-developer-hub. Ref to  backend-secret has also been changed from {{ .Release.Name }}-developer-hub-auth to {{ .Release.Name }}-auth. This patch incorporates those changes.