### PR TITLE
fix(RHIDP-4036): Enable locust cluster role

### DIFF
--- a/config/locust-k8s-operator.values.yaml
+++ b/config/locust-k8s-operator.values.yaml
@@ -2,6 +2,10 @@ image:
   repository: "quay.io/backstage-performance/locust-k8s-operator"
   tag: "latest"
 
+k8s:
+  clusterRole:
+    enabled: true
+
 config:
   loadGenerationPods:
     resource:


### PR DESCRIPTION
Currently, the the latest version of locust operator (v0.10.0) used in the benchmark framework fails to install while complaining:

```
locusttests.locust.io is forbidden: User "system:serviceaccount:locust-operator:locust-operator-locust-k8s-operator" cannot list resource "locusttests" in API group "locust.io" at the cluster scope.
```

Recently, the locust operator [changed permissions](https://github.com/AbdelrhmanHamouda/locust-k8s-operator/pull/218) and introduced a cluster role that is [disabled by default](https://github.com/AbdelrhmanHamouda/locust-k8s-operator/pull/218/files#diff-89ebcb039fac16a287767651f9a1061b3a2e097b58a65761d774b365ae914de0R43).

This PR enables it by setting the `k8s.clusterRole.enabled=true` value on the Helm chart while installing it.