### PR TITLE
fix(RHIDP-4374): Pin the version of oauth2-proxy image to v7.6.0

### DIFF
--- a/ci-scripts/rhdh-setup/template/backstage/helm/oauth2-container-patch.yaml
+++ b/ci-scripts/rhdh-setup/template/backstage/helm/oauth2-container-patch.yaml
@@ -26,7 +26,7 @@ extraContainers:
     containerPort: 4180
     protocol: TCP
   imagePullPolicy: IfNotPresent
-  image: quay.io/oauth2-proxy/oauth2-proxy:latest
+  image: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0
   args:
   - "--provider=oidc"
   - "--email-domain=*"

--- a/ci-scripts/rhdh-setup/template/backstage/olm/rhdh-oauth2.deployment.yaml
+++ b/ci-scripts/rhdh-setup/template/backstage/olm/rhdh-oauth2.deployment.yaml
@@ -43,7 +43,7 @@ spec:
               value: https://keycloak-${RHDH_NAMESPACE}.${OPENSHIFT_APP_DOMAIN}/auth/realms/backstage
             - name: OAUTH2_PROXY_SSL_INSECURE_SKIP_VERIFY
               value: "true"
-          image: quay.io/oauth2-proxy/oauth2-proxy:latest
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0
           imagePullPolicy: IfNotPresent
           name: oauth2-proxy
           ports:


### PR DESCRIPTION
The performance framework uses `latest` tag for `oauth2-proxy` image. [Recently](https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.7.0) the new version v7.7.0 was released where the handling of self-signed certificates and ignoring insecured TLS is [broken](https://github.com/oauth2-proxy/oauth2-proxy/pull/2803).

That breaks our framework.

This PR pins the version of `oauth2-proxy` image to `v7.6.0` (not the "latest").