### PR TITLE
fix(helm): Fix Helm chart latest version detection

### DIFF
--- a/ci-scripts/rhdh-setup/deploy.sh
+++ b/ci-scripts/rhdh-setup/deploy.sh
@@ -38,7 +38,7 @@ export RHDH_BASE_VERSION=${RHDH_BASE_VERSION:-1.7}
 
 export RHDH_HELM_REPO=${RHDH_HELM_REPO:-oci://quay.io/rhdh/chart}
 export RHDH_HELM_CHART=${RHDH_HELM_CHART:-redhat-developer-hub}
-export RHDH_HELM_CHART_VERSION=${RHDH_HELM_CHART_VERSION:-$(skopeo list-tags docker://quay.io/rhdh/chart | jq -rc '.Tags[]' | grep "${RHDH_BASE_VERSION//./\.}"'-.*' | sort -V | tail -n1)}
+export RHDH_HELM_CHART_VERSION=${RHDH_HELM_CHART_VERSION:-$(skopeo list-tags docker://quay.io/rhdh/chart | jq -rc '.Tags[]' | grep "${RHDH_BASE_VERSION//./\\.}"'-.*' | sort -V | tail -n1)}
 
 OCP_VER="$(oc version -o json | jq -r '.openshiftVersion' | sed -r -e "s#([0-9]+\.[0-9]+)\..+#\1#")"
 export RHDH_OLM_INDEX_IMAGE="${RHDH_OLM_INDEX_IMAGE:-quay.io/rhdh/iib:${RHDH_BASE_VERSION}-v${OCP_VER}-x86_64}"


### PR DESCRIPTION
Currently, the Helm latest version detection incorrectly detects latest version since the regex to filter versions based on the RHDH_BASE_VERSION was incorrect. The `.` in the regex is interpreted as regex special character for "any character" instead of just the dot.

For example if the base version is `1.7` and there is a newer version for 1.8 `1.8-107-CI` that `107` part of the version is matched and that version of 1.8 is incorrctly determined as latest 1.7.

This PR fixes the regex to correctly interpret the `.` as `.`.