### PR TITLE
fix(prow-job-spyglass): rename summary HTML files to be rendered as part of prow job page

### DIFF
--- a/ci-scripts/scalability/rhdh-perf-chart.py
+++ b/ci-scripts/scalability/rhdh-perf-chart.py
@@ -784,8 +784,10 @@ def generate_html_summary(chart_data, labels, output_dir, metadata=None):
 </html>
 '''
 
-    scenario_prefix = args.scenario.replace(' ', '_')
-    html_path = os.path.join(output_dir, f'{scenario_prefix}_summary.html')
+    scenario_prefix = os.path.basename(args.scenario.replace(' ', '_').replace('\\', '/'))
+    if not scenario_prefix or scenario_prefix in ('.', '..'):
+        scenario_prefix = 'scenario'
+    html_path = os.path.join(output_dir, f'{scenario_prefix}-summary.html')
     with open(html_path, 'w', encoding='utf-8') as f:
         f.write(html_content)
 
@@ -827,7 +829,5 @@ if generate_html and chart_data:
 print(f"\nSummary:")
 print(f"  Generated {len(chart_data)} chart(s)")
 if generate_html and chart_data:
-    scenario_prefix = args.scenario.replace(' ', '_')
-    print(
-        f"  Single HTML file with embedded charts: {os.path.join(output_dir, f'{scenario_prefix}_summary.html')}")
+    print(f"  Single HTML file with embedded charts: {html_path}")
 print(f"  Output directory: {output_dir}")


### PR DESCRIPTION
This PR:
* Renames generated HTML chart files from `*_summary.html` to `*-summary.html`.

The OpenShift CI Spyglass `html` lens (configured in [`openshift/release`](https://github.com/openshift/release)) renders HTML artifacts inline on the Prow job page when they match the pattern `.*-summary.*\.html`. Our files used an underscore instead of a dash, so they were silently skipped. This fix makes them show up inline without any changes to `openshift/release`.
