### PR TITLE
fix(RHIDP-15717): fix RHDH base version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ export RHDH_IMAGE_REPO ?=
 export RHDH_IMAGE_TAG ?=
 
 # RHDH base version
-export RHDH_BASE_VERSION ?= 1.10
+export RHDH_BASE_VERSION ?= 1.11
 
 # RHDH Helm chart to deploy
 export RHDH_NAMESPACE ?= rhdh-performance


### PR DESCRIPTION
Followup to https://github.com/redhat-performance/backstage-performance/pull/412

This PR:
* fixes the base version in Makefile missed in the previous PR